### PR TITLE
Add expected directory to set file

### DIFF
--- a/F-22-jsbsim-set.xml
+++ b/F-22-jsbsim-set.xml
@@ -5,6 +5,7 @@
 	<sim>
 
 		<description>F-22A (JSBSim FDM)</description>
+		<expected-aircraft-dir-name>F-22</expected-aircraft-dir-name>
 <variant-id type="int">1</variant-id>
         <long-description>
             The Lockheed Martin F-22A "Raptor" is a fifth-generation tactical fighter manufactured by Lockheed Martin and Boeing. It combines supersonic cruise, low-observability, and sensor fusion. The definitive production Block 30/35 model features the AN/APG-77v1 AESA radar and F119-PW-100 engines. The F-22A, the only production F-22 variant, became operational in 2005 and is operated exclusively by the United States Air Force.


### PR DESCRIPTION
This adds the `expected-aircraft-dir-name` tag to the set file, clearing confusion if the directory is set incorrectly.

## References
- https://github.com/BobDotCom/B-1B/blob/master/b1-base.xml#L13
- https://github.com/NikolaiVChr/f16/blob/master/f16-base.xml#L18
- NikolaiVChr/f16#541